### PR TITLE
html paragraphs must be enclosed in p tags for proper spacing

### DIFF
--- a/client/html.coffee
+++ b/client/html.coffee
@@ -1,7 +1,7 @@
 sanitize = require 'sanitize-caja'
 
 emit = ($item, item) ->
-	$item.append sanitize item.text
+	$item.append "<p>#{sanitize item.text}</p>"
 
 bind = ($item, item) ->
 	$item.dblclick -> wiki.textEditor $item, item

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
     
     watch: {
       all: {
-        files: ['*.coffee'],
+        files: ['client/*.coffee'],
         tasks: ['browserify']
       }
     }


### PR DESCRIPTION
If we convert a Paragraph with tags to an HTML then we will expect the latter to be spaced in the story the same as the former. This requires wrapping HTML with extra p tags as is done with Paragraphs.

Pull request for wiki-client coming soon.
