### PR TITLE
use future, not fork, to make new page

### DIFF
--- a/client/html.coffee
+++ b/client/html.coffee
@@ -9,7 +9,15 @@ sanitize = require 'sanitize-caja'
 
 builtins =
   'http://new_page/': (params) ->
-    {title: params.title}
+    "title": params.title,
+    "story": [
+      "id": "98234090910324",
+      "type": "future",
+      "text": "Click to create this page.",
+      "title": params.title
+    ],
+    "journal": []
+
 
 emit = ($item, item) ->
   $item.append "<p>#{wiki.resolveLinks(item.text, sanitize)}</p>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-html",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Federated Wiki - HTML Plug-in",
   "keywords": [
     "wiki",


### PR DESCRIPTION
This improves on the recently merged #12.

Here we compare clicking on an unimplemented link to creating a page with a builtin submit handler.

![image](https://user-images.githubusercontent.com/12127/31866749-1ed7360e-b739-11e7-8684-11cc215d777c.png)

This improves on the earlier version.
- recognizes available templates
- creates new page with a proper journal

 but still leaves some unfortunate discrepancies.
- fails to notice twins in the neighborhood
- fails to observe shift-key convention which is not available on submit buttons
- fails with 409 status if page already exists

This new page logic appears in three locations: missing page from link, fork to delete page, and now here. Uniformity will come from moving the best version into, say pageObject, where it will be available to core and plugin javascript.