### PR TITLE
stop dblclick for inputs

### DIFF
--- a/client/html.coffee
+++ b/client/html.coffee
@@ -24,6 +24,7 @@ emit = ($item, item) ->
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item
+  $item.find('input').dblclick (e) -> e.stopPropagation()
 
   $item.on 'submit', (e) ->
 


### PR DESCRIPTION
Prevent double-click from opening text editor when clicks land on input element. 

![image](https://user-images.githubusercontent.com/12127/32873253-da294a6e-ca3f-11e7-9272-fa7d643e17dc.png)
