### PR TITLE
future plugin expects empty journal

### DIFF
--- a/client/html.js
+++ b/client/html.js
@@ -10,9 +10,7 @@ const dependencyLoaded = import('/plugins/html/DOMPurify-2.3.3/purify.min.js');
 
 builtins = {
   'http://new_page/': params => {
-    const clone = obj => JSON.parse(JSON.stringify(obj))
-    const date = Date.now()
-    const page = {
+    return {
       "title": params.title,
       "story": [
         {
@@ -21,10 +19,9 @@ builtins = {
           "text": "Click to create this page.",
           "title": params.title
         }
-      ]
+      ],
+      "journal": []
     }
-    page.journal = []
-    return page
   }
 };
 

--- a/client/html.js
+++ b/client/html.js
@@ -23,7 +23,7 @@ builtins = {
         }
       ]
     }
-    page.journal = [{type: "create", date, item:clone(page)}]
+    page.journal = []
     return page
   }
 };


### PR DESCRIPTION
We see multiple creates when creating pages with the html plugin special form action handler.

Create a new page as ghost with future plugin. See one create actions.
Create the actual page with the future's create button. See two create actions.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/12127/161829771-8ca2fc9a-3a7c-4a22-bcd3-3975b9e1bfa4.png">


This is correct on the server, but not on the client.

Fork the page with two creates. See two creates and one fork.

Now it is incorrect on the server too. By now it cannot be deleted by our "fork back to create" because the first create shows  (incorrectly?) a ghost page that can't be forked.